### PR TITLE
Support additional source sets in gradle builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+build
 .*
 !/.gitignore
 !/.travis.yml

--- a/cdi-unit-tests-gradle/build.gradle
+++ b/cdi-unit-tests-gradle/build.gradle
@@ -1,17 +1,37 @@
 apply plugin: 'java'
 
 repositories {
-    
+
     mavenCentral()
     mavenLocal()
 }
 
+sourceSets {
+    integTest {
+        java.srcDir file('src/integTest/java')
+        resources.srcDir file('src/integTest/resources')
+    }
+}
+
+task integTest(type: Test) {
+    testClassesDir = sourceSets.integTest.output.classesDir
+    classpath = sourceSets.integTest.runtimeClasspath
+}
+
+check.dependsOn integTest
+
 dependencies {
-	testCompile group: 'junit', name:'junit', version:'4.8.2'
-	testCompile group: 'org.slf4j', name:'slf4j-api', version:'1.7.5'
-	testCompile files('../cdi-unit/target/cdi-unit-' + projectVersionProp + '.jar')
-	testCompile group: 'org.jboss.weld.se', name:'weld-se-core', version:weldVersionProp
-	testCompile group: 'org.apache.deltaspike.core', name:'deltaspike-core-impl', version:'0.6'	
-	testCompile group: 'org.reflections', name:'reflections', version: '0.9.9-RC1'
-	 
+    integTestCompile sourceSets.main.output
+    integTestCompile configurations.testCompile
+    integTestCompile sourceSets.test.output
+    integTestRuntime configurations.testRuntime
+
+    testCompile group: 'junit', name: 'junit', version: '4.8.2'
+    testCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.5'
+    testCompile files('../cdi-unit/target/cdi-unit-' + projectVersionProp + '.jar')
+    testCompile group: 'org.jboss.weld.se', name: 'weld-se-core', version: weldVersionProp
+    testCompile group: 'org.apache.deltaspike.core', name: 'deltaspike-core-impl', version: '0.6'
+    testCompile(group: 'org.reflections', name: 'reflections', version: '0.9.9') {
+    }
+
 }

--- a/cdi-unit-tests-gradle/src/integTest/java/org/jglue/cdiunit/TestCdiRunnerIntegrationTest.java
+++ b/cdi-unit-tests-gradle/src/integTest/java/org/jglue/cdiunit/TestCdiRunnerIntegrationTest.java
@@ -1,0 +1,22 @@
+package org.jglue.cdiunit;
+
+
+import org.junit.Test;
+import org.junit.cdiunit.NonTestClass;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(CdiRunner.class)
+public class TestCdiRunnerIntegrationTest {
+
+	@Inject
+	private NonTestClass nonTestClass;
+
+	@Test
+	public void testStart() {
+		assertNotNull(nonTestClass);
+	}
+}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
@@ -385,7 +385,7 @@ public class WeldTestUrlDeployment implements Deployment {
 				boolean cdiUnit = url.equals(CdiRunner.class.getProtectionDomain().getCodeSource().getLocation());
 				boolean mavenClasses = url.getFile().endsWith("/test-classes/");
 				boolean generatedClasses = url.getFile().contains("/generated-classes/");
-				boolean gradleClasses = url.getFile().endsWith("/classes/test/") || url.getFile().endsWith("/classes/main/");
+				boolean gradleClasses = url.getFile().matches(".*/classes/[\\w\\-]*/");
 				if (cdiUnit || resource != null || mavenClasses || gradleClasses || generatedClasses) {
 					cdiClasspathEntries.add(url);
 				}


### PR DESCRIPTION
Hi,
in gradle builds it is quite common to have multiple source sets. This PR will recognize all source sets with the default layout and make them available as CDI bean archives for CDI Unit. Basically, it is a generalization of the fix for Issue #25 (although it still is a hack).  As an example I added an integTest source set to the test project which wasn't possible before.
Regards,
Mario