### PR TITLE
Allow createTest() to be overridden by subclasses

### DIFF
--- a/cdi-unit/src/main/java/org/jglue/cdiunit/CdiRunner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/CdiRunner.java
@@ -150,7 +150,7 @@ public class CdiRunner extends BlockJUnit4ClassRunner {
 		}
 	}
 
-	private <T> T createTest(Class<T> testClass) {
+	protected <T> T createTest(Class<T> testClass) throws Exception {
 
 		T t = container.instance().select(testClass).get();
 


### PR DESCRIPTION
This change makes it possible to combine @RunWith(Parameterized.class) and
CdiRunner under JUnit 4.12.  See http://stackoverflow.com/a/27750897/14379
for the general approach.
