### PR TITLE
Fixes for EJBs not being properly resolved and injected by cdi-unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: java
 notifications:
   email:
-    - alpapad@gmail.com
+    - bryncooke@gmail.com
 jdk:
   - oraclejdk7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: java
 notifications:
   email:
-    - bryncooke@gmail.com
+    - alpapad@gmail.com
 jdk:
   - oraclejdk7
 

--- a/cdi-unit/pom.xml
+++ b/cdi-unit/pom.xml
@@ -36,9 +36,9 @@
 			<groupId>org.jboss.weld.se</groupId>
 			<artifactId>weld-se-core</artifactId>
 			<scope>compile</scope>
-			<version>2.2.13.Final</version>
+			<version>2.3.2.Final</version>
 		</dependency>
-
+		
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -142,7 +142,7 @@
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-jaxrs</artifactId>
-			<version>3.0.8.Final</version>
+			<version>3.0.14.Final</version>
 			
 		</dependency>
 	</dependencies>

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
@@ -88,7 +88,7 @@ public class WeldTestUrlDeployment implements Deployment {
 		try {
 			beansXml = new BeansXmlImpl(new ArrayList<Metadata<String>>(), new ArrayList<Metadata<String>>(),
 					new ArrayList<Metadata<String>>(), new ArrayList<Metadata<String>>(), Scanning.EMPTY_SCANNING, new URL(
-							"file:cdi-unit"), BeanDiscoveryMode.ALL, "cdi-unit");
+							"file:cdi-unit"), BeanDiscoveryMode.ANNOTATED, "cdi-unit");
 		} catch (NoClassDefFoundError e) {
 			try {
 				beansXml = (BeansXml) BeansXmlImpl.class.getConstructors()[0].newInstance(new ArrayList<Metadata<String>>(),

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ejb/EJbName.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ejb/EJbName.java
@@ -26,17 +26,15 @@ import javax.inject.Qualifier;
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
-public @interface EJbQualifier {
+public @interface EJbName {
 	String name() default "";
 
-	public static class EJbQualifierLiteral extends AnnotationLiteral<EJbQualifier> implements EJbQualifier {
+	public static class EJbNameLiteral extends AnnotationLiteral<EJbName> implements EJbName {
 
 		private static final long serialVersionUID = 6325669711688098239L;
 		private final String name;
 				
-		public final static EJbQualifierLiteral INSTANCE = new EJbQualifierLiteral("");
-		
-		public EJbQualifierLiteral(String name) {
+		public EJbNameLiteral(String name) {
 			this.name = name;
 		}
 
@@ -44,5 +42,11 @@ public @interface EJbQualifier {
 		public String name() {
 			return name;
 		}
+
+		@Override
+		public String toString() {
+			return "EJbQualifierLiteral [name=" + name + "]";
+		}
+		
 	}
 }

--- a/cdi-unit/src/test/java/org/jglue/cdiunit/TestEjb.java
+++ b/cdi-unit/src/test/java/org/jglue/cdiunit/TestEjb.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
 public class TestEjb {
 
 	@EJB
-	private EJBI inject;
+	private EJBA inject;
 
 	@EJB(beanName = "named")
 	private EJBI injectNamed;
@@ -66,7 +66,7 @@ public class TestEjb {
 
 
 
-	@EJB(name = "named")
+	@EJB(beanName = "named")
 	@Produces
 	public EJBA providesNamed() {
 		return expectedNamed;
@@ -87,6 +87,7 @@ public class TestEjb {
 
 	}
 
+	@Stateless
 	public static class EJBA implements EJBI {
 
 	}
@@ -96,7 +97,7 @@ public class TestEjb {
 
 	}
 
-	@Stateless
+	@Stateless(name="TestEjb.EJBStateless")
 	public static class EJBStateless implements EJBI {
 
 	}
@@ -106,7 +107,7 @@ public class TestEjb {
 
 	}
 
-	@Stateless
+	@Stateless(name="TestEjb.EJBStateful")
 	public static class EJBStateful implements EJBI {
 
 	}
@@ -116,7 +117,7 @@ public class TestEjb {
 
 	}
 
-	@Singleton
+	@Singleton(name="TestEjb.EJBSingleton")
 	public static class EJBSingleton implements EJBI {
 
 	}


### PR DESCRIPTION
Hi,

I have modified the EJB resolving process so it will work on a more realistic environment than the one in the unit tests. 

In my experience EJBs are usually not "named"  and the current code works properly only when EJBs  and their injection points have a name/beanName parameter.


The PR does the following:

a) add EJBs in the application scope.
b) adds a specific annotation as a qualifier to be used both by classes/producers and injection points
c) if a name is defined it adds a second qualifier for the specific name..

Finally, libraries are updated to latest weld AND the Bean Discovery mode is set to Annotated (this is anyway the default for CDI 1.2)

What we are still missing is:
a) support for @Resource and the rest of J2EE components (well some of them) as these are defined by the CDI spec.
b) a way to alter the  Bean Discovery mode (by a new annotation??)  for cdi-unit.


 