### PR TITLE
Add support for ProducerConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ build
 .*
 !/.gitignore
 !/.travis.yml
+# IntelliJ
+*.iml
+# Eclipse
+.classpath
+.project

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/NgCdiRunner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/NgCdiRunner.java
@@ -1,6 +1,7 @@
 package org.jglue.cdiunit;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.AnnotatedType;
@@ -29,18 +30,17 @@ public class NgCdiRunner {
     private InitialContext initialContext;
 
     /**
-     * Setup CDI environment for the class.<br>
-     * INTERNAL: Do not use.
+     * Initialize the CDI container.<br>
+     * PUBLIC: Should be used only in DataProvider methods which require injection.
      */
-    @BeforeClass(alwaysRun = true)
-    protected void setupCdi() {
-        
+    @BeforeMethod(alwaysRun = true)
+    public void initializeCdi(final Method method) {
         weld = new Weld() {
         	
         	protected Deployment createDeployment(
         			ResourceLoader resourceLoader, CDI11Bootstrap bootstrap) {
         		try {
-                    return new WeldTestUrlDeployment(resourceLoader, bootstrap, clazz);
+                    return new WeldTestUrlDeployment(resourceLoader, bootstrap, clazz, method);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -48,20 +48,13 @@ public class NgCdiRunner {
             
             protected Deployment createDeployment(ResourceLoader resourceLoader, Bootstrap bootstrap) {
                 try {
-                    return new WeldTestUrlDeployment(resourceLoader, bootstrap, clazz);
+                    return new WeldTestUrlDeployment(resourceLoader, bootstrap, clazz, method);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
             }
         };
-    }
 
-    /**
-     * Initialize the CDI container.<br>
-     * PUBLIC: Should be used only in DataProvider methods which require injection.
-     */
-    @BeforeMethod(alwaysRun = true)
-    public void initializeCdi() {
         container = weld.initialize();
         BeanManager beanManager = container.getBeanManager();
         CreationalContext creationalContext = beanManager.createCreationalContext(null);

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/ProducerConfig.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/ProducerConfig.java
@@ -1,0 +1,12 @@
+package org.jglue.cdiunit;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(ANNOTATION_TYPE)
+public @interface ProducerConfig {
+}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ProducerConfigExtension.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/ProducerConfigExtension.java
@@ -1,0 +1,107 @@
+package org.jglue.cdiunit.internal;
+
+import org.jglue.cdiunit.ProducerConfig;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.*;
+import javax.enterprise.util.AnnotationLiteral;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ProducerConfigExtension implements Extension {
+
+	private Method testMethod;
+
+	public ProducerConfigExtension(Method testMethod) {
+		this.testMethod = testMethod;
+	}
+
+	@SuppressWarnings("unused")
+	void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager bm) throws Exception {
+		for (final Annotation annotation : testMethod.getAnnotations()) {
+			if (!annotation.annotationType().isAnnotationPresent(ProducerConfig.class)) {
+				continue;
+			}
+			if (!Modifier.isPublic(annotation.annotationType().getModifiers())) {
+				throw new RuntimeException("ProducerConfig annotation classes must be public");
+			}
+			AnnotatedType<? extends Annotation> at = bm.createAnnotatedType(annotation.getClass());
+			final InjectionTarget<? extends Annotation> it = bm.createInjectionTarget(at);
+			abd.addBean(new Bean<Annotation>() {
+				@Override
+				public Class<?> getBeanClass() {
+					return annotation.annotationType();
+				}
+
+				@Override
+				public Set<InjectionPoint> getInjectionPoints() {
+					return it.getInjectionPoints();
+				}
+
+				@Override
+				public String getName() {
+					return null;
+				}
+
+				@Override
+				public Set<Annotation> getQualifiers() {
+					Set<Annotation> qualifiers = new HashSet<Annotation>();
+					qualifiers.add(new AnnotationLiteral<Default>() {});
+					qualifiers.add(new AnnotationLiteral<Any>() {});
+					return qualifiers;
+				}
+
+				@Override
+				public Class<? extends Annotation> getScope() {
+					return ApplicationScoped.class;
+				}
+
+				@Override
+				public Set<Class<? extends Annotation>> getStereotypes() {
+					return Collections.emptySet();
+				}
+
+				@Override
+				public Set<Type> getTypes() {
+					Set<Type> types = new HashSet<Type>();
+					types.add(annotation.annotationType());
+					types.add(Annotation.class);
+					types.add(Object.class);
+					return types;
+				}
+
+				@Override
+				public boolean isAlternative() {
+					return false;
+				}
+
+				@Override
+				public boolean isNullable() {
+					return false;
+				}
+
+				@Override
+				public Annotation create(CreationalContext<Annotation> ctx) {
+					return annotation;
+				}
+
+				@Override
+				public void destroy(Annotation instance,
+									CreationalContext<Annotation> ctx) {
+					ctx.release();
+				}
+
+			});
+		}
+	}
+
+}

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/Weld11TestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/Weld11TestUrlDeployment.java
@@ -16,6 +16,7 @@
 package org.jglue.cdiunit.internal;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.jboss.weld.bootstrap.spi.CDI11Deployment;
@@ -24,8 +25,8 @@ import org.jboss.weld.resources.spi.ResourceLoader;
 public class Weld11TestUrlDeployment extends WeldTestUrlDeployment implements CDI11Deployment {
 
 	public Weld11TestUrlDeployment(ResourceLoader resourceLoader,
-			Bootstrap bootstrap, Class<?> testClass) throws IOException {
-		super(resourceLoader, bootstrap, testClass);
+			Bootstrap bootstrap, Class<?> testClass, Method testMethod) throws IOException {
+		super(resourceLoader, bootstrap, testClass, testMethod);
 	}
 	
 }

--- a/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/internal/WeldTestUrlDeployment.java
@@ -81,7 +81,7 @@ public class WeldTestUrlDeployment implements Deployment {
 	private Set<URL> cdiClasspathEntries = new HashSet<URL>();
 	private final ServiceRegistry serviceRegistry = new SimpleServiceRegistry();
 
-	public WeldTestUrlDeployment(ResourceLoader resourceLoader, Bootstrap bootstrap, Class<?> testClass) throws IOException {
+	public WeldTestUrlDeployment(ResourceLoader resourceLoader, Bootstrap bootstrap, Class<?> testClass, Method testMethod) throws IOException {
 
 		populateCdiClasspathSet();
 		BeansXml beansXml;
@@ -109,6 +109,9 @@ public class WeldTestUrlDeployment implements Deployment {
 
 		classesToProcess.add(testClass);
 		extensions.add(new MetadataImpl<Extension>(new TestScopeExtension(testClass), TestScopeExtension.class.getName()));
+		if (testMethod != null) {
+			extensions.add(new MetadataImpl<Extension>(new ProducerConfigExtension(testMethod), ProducerConfigExtension.class.getName()));
+		}
 
 		try {
 			Class.forName("javax.faces.view.ViewScoped");

--- a/cdi-unit/src/test/java/org/jglue/cdiunit/TestNgProducerConfig.java
+++ b/cdi-unit/src/test/java/org/jglue/cdiunit/TestNgProducerConfig.java
@@ -1,0 +1,47 @@
+package org.jglue.cdiunit;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@AdditionalClasses(TestNgProducerConfig.Producers.class)
+public class TestNgProducerConfig extends NgCdiRunner {
+
+	@Inject @Named("a")
+	private String valueNamedA;
+
+	// an example ProducerConfig annotation
+	@Retention(RUNTIME)
+	@Target(METHOD)
+	@ProducerConfig
+	public @interface ProducerConfigNum {
+		int value();
+	}
+
+	// Producers kept out of the injected test class to avoid Weld circularity warnings:
+	static class Producers {
+		@Produces @Named("a")
+		private String getValueA(ProducerConfigNum config) {
+			return "A" + config.value();
+		}
+	}
+
+	@Test @ProducerConfigNum(1)
+	public void testA1() {
+		Assert.assertEquals("A1", valueNamedA);
+	}
+
+	@Test @ProducerConfigNum(2)
+	public void testA2() {
+		Assert.assertEquals("A2", valueNamedA);
+	}
+
+}

--- a/cdi-unit/src/test/java/org/jglue/cdiunit/TestProducerConfig.java
+++ b/cdi-unit/src/test/java/org/jglue/cdiunit/TestProducerConfig.java
@@ -1,0 +1,50 @@
+package org.jglue.cdiunit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@RunWith(CdiRunner.class)
+@AdditionalClasses(TestProducerConfig.Producers.class)
+public class TestProducerConfig {
+
+	@Inject @Named("a")
+	private String valueNamedA;
+
+	// example ProducerConfig annotations
+	@Retention(RUNTIME)
+	@Target(METHOD)
+	@ProducerConfig
+	public @interface ProducerConfigNum {
+		int value();
+	}
+
+	// Producers kept out of the injected test class to avoid Weld circularity warnings:
+	static class Producers {
+		@Produces @Named("a")
+		private String getValueA(ProducerConfigNum config) {
+			return "A" + config.value();
+		}
+
+	}
+
+	@Test @ProducerConfigNum(1)
+	public void testA1() {
+		Assert.assertEquals("A1", valueNamedA);
+	}
+
+	@Test @ProducerConfigNum(2)
+	public void testA2() {
+		Assert.assertEquals("A2", valueNamedA);
+	}
+
+}

--- a/cdi-unit/src/test/java/org/jglue/cdiunit/TestProducerConfig.java
+++ b/cdi-unit/src/test/java/org/jglue/cdiunit/TestProducerConfig.java
@@ -9,23 +9,37 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.HashSet;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @RunWith(CdiRunner.class)
 @AdditionalClasses(TestProducerConfig.Producers.class)
+@TestProducerConfig.ProducerConfigClass(Object.class) @TestProducerConfig.ProducerConfigNum(0)
 public class TestProducerConfig {
 
 	@Inject @Named("a")
 	private String valueNamedA;
 
+	@Inject @Named("object")
+	private Object object;
+
 	// example ProducerConfig annotations
 	@Retention(RUNTIME)
-	@Target(METHOD)
+	@Target({METHOD, TYPE})
 	@ProducerConfig
 	public @interface ProducerConfigNum {
 		int value();
+	}
+
+	@Retention(RUNTIME)
+	@Target({METHOD, TYPE})
+	@ProducerConfig
+	public @interface ProducerConfigClass {
+		Class<?> value();
 	}
 
 	// Producers kept out of the injected test class to avoid Weld circularity warnings:
@@ -35,6 +49,10 @@ public class TestProducerConfig {
 			return "A" + config.value();
 		}
 
+		@Produces @Named("object")
+		private Object getObject(ProducerConfigClass config) throws Exception {
+			return config.value().newInstance();
+		}
 	}
 
 	@Test @ProducerConfigNum(1)
@@ -45,6 +63,16 @@ public class TestProducerConfig {
 	@Test @ProducerConfigNum(2)
 	public void testA2() {
 		Assert.assertEquals("A2", valueNamedA);
+	}
+
+	@Test @ProducerConfigClass(ArrayList.class)
+	public void testArrayList() {
+		Assert.assertEquals(ArrayList.class, object.getClass());
+	}
+
+	@Test @ProducerConfigClass(HashSet.class)
+	public void testHashSet() {
+		Assert.assertEquals(HashSet.class, object.getClass());
 	}
 
 }


### PR DESCRIPTION
This allows test methods to be annotated with custom ProducerConfig annotations holding configuration values. When the test is run, these values can be injected, allowing producer methods to change their behaviour. Default config can also be provided by class-level annotations.

(In other words, this makes it possible to keep tests, some of which need one or two different values injected, in the same test class, instead of having to split them up into multiple test classes.)

See TestProducerConfig for an example.