### PR TITLE
Allow use of custom contextFactory

### DIFF
--- a/cdi-unit/src/main/java/org/jglue/cdiunit/CdiRunner.java
+++ b/cdi-unit/src/main/java/org/jglue/cdiunit/CdiRunner.java
@@ -173,7 +173,9 @@ public class CdiRunner extends BlockJUnit4ClassRunner {
 					}
 					throw startupException;
 				}
-				System.setProperty("java.naming.factory.initial", "org.jglue.cdiunit.internal.naming.CdiUnitContextFactory");
+				if (System.getProperty("java.naming.factory.initial") == null) {
+					System.setProperty("java.naming.factory.initial", "org.jglue.cdiunit.internal.naming.CdiUnitContextFactory");
+				}
 				InitialContext initialContext = new InitialContext();
 				initialContext.bind("java:comp/BeanManager", container.getBeanManager());
 


### PR DESCRIPTION
Current implementation of InitialContext is partial and may not be
sufficient for some use-case. This commit allows to use a custom
InitialContextFactory. CDIUnitContextFactory is then used only if no
factory is previously set.
