### PR TITLE
Upgrade to a recent version of Mockito

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See website for full details http://jglue.org/cdi-unit
 <dependency>
   <groupId>org.jglue.cdi-unit</groupId>
   <artifactId>cdi-unit</artifactId>
-  <version>3.1.4</version>
+  <version>3.2.0</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/cdi-unit-tests-bare/pom.xml
+++ b/cdi-unit-tests-bare/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-Bare</name>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.jglue.cdi-unit</groupId>
 			<artifactId>cdi-unit</artifactId>
-			<version>3.1.5-SNAPSHOT</version>
+			<version>3.2.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jboss.weld.se</groupId>

--- a/cdi-unit-tests-easymock/pom.xml
+++ b/cdi-unit-tests-easymock/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-EasyMock</name>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.jglue.cdi-unit</groupId>
 			<artifactId>cdi-unit</artifactId>
-			<version>3.1.5-SNAPSHOT</version>
+			<version>3.2.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jboss.weld.se</groupId>

--- a/cdi-unit-tests-external-dependency/pom.xml
+++ b/cdi-unit-tests-external-dependency/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-ExternalDependency</name>

--- a/cdi-unit-tests-jandex/pom.xml
+++ b/cdi-unit-tests-jandex/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-Jandex</name>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.jglue.cdi-unit</groupId>
 			<artifactId>cdi-unit</artifactId>
-			<version>3.1.5-SNAPSHOT</version>
+			<version>3.2.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jboss.weld.se</groupId>

--- a/cdi-unit-tests-mockito/pom.xml
+++ b/cdi-unit-tests-mockito/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests-Mockito</name>
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.jglue.cdi-unit</groupId>
 			<artifactId>cdi-unit</artifactId>
-			<version>3.1.5-SNAPSHOT</version>
+			<version>3.2.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jboss.weld.se</groupId>
@@ -58,8 +58,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.9.5</version>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.27</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/cdi-unit-tests/pom.xml
+++ b/cdi-unit-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit-Tests</name>
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.jglue.cdi-unit</groupId>
 			<artifactId>cdi-unit</artifactId>
-			<version>3.1.5-SNAPSHOT</version>
+			<version>3.2.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.jboss.weld.se</groupId>
@@ -59,8 +59,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.9.5</version>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.27</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.jglue.cdi-unit</groupId>
 			<artifactId>cdi-unit-tests-external-dependency</artifactId>
-			<version>3.1.5-SNAPSHOT</version>
+			<version>3.2.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/cdi-unit/pom.xml
+++ b/cdi-unit/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.jglue.cdi-unit</groupId>
 		<artifactId>cdi-unit-parent</artifactId>
-		<version>3.1.5-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>CDI-Unit</name>
@@ -53,8 +53,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.9.5</version>
+			<artifactId>mockito-core</artifactId>
+			<version>2.2.27</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jglue.cdi-unit</groupId>
 	<artifactId>cdi-unit-parent</artifactId>
-	<version>3.1.5-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.sonatype.oss</groupId>


### PR DESCRIPTION
Mockito 2.x adds Java 8 support, improved generics support, mocking of final methods (optional), and much more.